### PR TITLE
Add SELinux policy for gmscore_app (allow login without `setenforcing 0`)

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -71,4 +71,14 @@ find $InstallDir/etc/default-permissions -type f -exec chcon --reference=$Instal
 find $InstallDir/etc/preferred-apps -type f -exec chcon --reference=$InstallDir/etc/fs_config_dirs {} \;
 find $InstallDir/etc/sysconfig -type f -exec chcon --reference=$InstallDir/etc/fs_config_dirs {} \;
 
+echo "Applying SELinux policy"
+# Sed will remove the SELinux policy for plat_sepolicy.cil, preserve policy using cp
+cp $InstallDir/etc/selinux/plat_sepolicy.cil $InstallDir/etc/selinux/plat_sepolicy_new.cil
+sed -i 's/(allow gmscore_app self (process (ptrace)))/(allow gmscore_app self (process (ptrace)))\n(allow gmscore_app self (vsock_socket (read write create connect)))\n(allow gmscore_app device_config_runtime_native_boot_prop (file (read)))/g' $InstallDir/etc/selinux/plat_sepolicy_new.cil
+cp $InstallDir/etc/selinux/plat_sepolicy_new.cil $InstallDir/etc/selinux/plat_sepolicy.cil
+rm $InstallDir/etc/selinux/plat_sepolicy_new.cil
+
+# Prevent android from using cached SELinux policy
+echo '0000000000000000000000000000000000000000000000000000000000000000' > $InstallDir/etc/selinux/plat_sepolicy_and_mapping.sha256
+
 echo "!! Apply completed !!"


### PR DESCRIPTION
Allow login without modifying kernel.