### PR TITLE
Shrink image after unmount

### DIFF
--- a/unmount_images.sh
+++ b/unmount_images.sh
@@ -14,4 +14,28 @@ umount $MountPointSystem
 echo "Unmounting vendor.img"
 umount $MountPointVendor
 
+echo "chk product.img"
+e2fsck -f $ImagesRoot/product.img
+
+echo "Resizing product.img"
+resize2fs -M $ImagesRoot/product.img
+
+echo "chk system.img"
+e2fsck -f $ImagesRoot/system.img
+
+echo "Resizing system.img"
+resize2fs -M $ImagesRoot/system.img
+
+echo "chk system_ext.img"
+e2fsck -f $ImagesRoot/system_ext.img
+
+echo "Resizing system_ext.img"
+resize2fs -M $ImagesRoot/system_ext.img
+
+echo "chk vendor.img"
+e2fsck -f $ImagesRoot/vendor.img
+
+echo "Resizing vendor.img"
+resize2fs -M $ImagesRoot/vendor.img
+
 echo "!! Unmounting completed !!"


### PR DESCRIPTION
Shrinking images leads to smaller images sizes.

todo:
We should also consider rename `unmount_images.sh` to `unmount_and_shrink_images.sh`.
If we rename the file, then we need to modify README.md too.
