### PR TITLE
Fix path to system `build.prop`

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -148,7 +148,7 @@ find $MountPointProduct/overlay -type f -exec chcon --reference=$MountPointVendo
 find $MountPointProduct/priv-app -type f -exec chcon --reference=$MountPointProduct/priv-app/amazon-adm-release/amazon-adm-release.apk {} \;
 
 echo "Applying SELinux security contexts to props"
-chcon --reference=$MountPointSystem/system/etc $MountPointSystem/build.prop
+chcon --reference=$MountPointSystem/system/etc $MountPointSystem/system/build.prop
 chcon --reference=$MountPointSystemExt/etc $MountPointSystemExt/build.prop
 chcon --reference=$MountPointProduct/etc $MountPointProduct/build.prop
 chcon --reference=$MountPointVendor/etc $MountPointVendor/build.prop


### PR DESCRIPTION
There is a small mistake in #82, which leads to error
```
chcon: cannot access '/mnt/system/build.prop': No such file or directory
```
See https://github.com/KiruyaMomochi/WSASystemPatchScript/runs/4058025387?check_suite_focus=true#step:14:17

This pr fixes it.